### PR TITLE
Add cluster-operator-fyre chart

### DIFF
--- a/gitops-charts/cluster-operator-fyre/Chart.yaml
+++ b/gitops-charts/cluster-operator-fyre/Chart.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: v1
+name: cluster-operator-fyre
+description: Cluster Operator for Fyre
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.0.15
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+appVersion: "0.0.15"

--- a/gitops-charts/cluster-operator-fyre/templates/deployment-all.yaml
+++ b/gitops-charts/cluster-operator-fyre/templates/deployment-all.yaml
@@ -1,0 +1,299 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: openshiftfyres.clusters.ibm.com
+spec:
+  group: clusters.ibm.com
+  names:
+    kind: OpenShiftFyre
+    listKind: OpenShiftFyreList
+    plural: openshiftfyres
+    shortNames:
+    - ocpfyre
+    singular: openshiftfyre
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: OpenShiftFyre is the Schema for the openshiftfyres API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of OpenShiftFyre
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            description: Status defines the observed state of OpenShiftFyre
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cluster-operator-fyre-controller-manager
+  namespace: {{ default "default" .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cluster-operator-fyre-leader-election-role
+  namespace: {{ default "default" .Release.Namespace }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cluster-operator-fyre-manager-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  - pods
+  - pods/exec
+  - pods/log
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  - replicasets
+  - statefulsets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - clusters.ibm.com
+  resources:
+  - openshiftfyres
+  - openshiftfyres/status
+  - openshiftfyres/finalizers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cluster-operator-fyre-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cluster-operator-fyre-proxy-role
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cluster-operator-fyre-leader-election-rolebinding
+  namespace: {{ default "default" .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cluster-operator-fyre-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: cluster-operator-fyre-controller-manager
+  namespace: {{ default "default" .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cluster-operator-fyre-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-operator-fyre-manager-role
+subjects:
+- kind: ServiceAccount
+  name: cluster-operator-fyre-controller-manager
+  namespace: {{ default "default" .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cluster-operator-fyre-proxy-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-operator-fyre-proxy-role
+subjects:
+- kind: ServiceAccount
+  name: cluster-operator-fyre-controller-manager
+  namespace: {{ default "default" .Release.Namespace }}
+---
+apiVersion: v1
+data:
+  controller_manager_config.yaml: |
+    apiVersion: controller-runtime.sigs.k8s.io/v1alpha1
+    kind: ControllerManagerConfig
+    health:
+      healthProbeBindAddress: :6789
+    metrics:
+      bindAddress: 127.0.0.1:8080
+    leaderElection:
+      leaderElect: true
+      resourceName: 811c9dc5.ibm.com
+kind: ConfigMap
+metadata:
+  name: cluster-operator-fyre-manager-config
+  namespace: {{ default "default" .Release.Namespace }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: cluster-operator-fyre-controller-manager-metrics-service
+  namespace: {{ default "default" .Release.Namespace }}
+spec:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: https
+  selector:
+    control-plane: controller-manager
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: cluster-operator-fyre-controller-manager
+  namespace: {{ default "default" .Release.Namespace }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+  template:
+    metadata:
+      labels:
+        control-plane: controller-manager
+    spec:
+      containers:
+      - args:
+        - --secure-listen-address=0.0.0.0:8443
+        - --upstream=http://127.0.0.1:8080/
+        - --logtostderr=true
+        - --v=10
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 8443
+          name: https
+          protocol: TCP
+      - args:
+        - --health-probe-bind-address=:6789
+        - --metrics-bind-address=127.0.0.1:8080
+        - --leader-elect
+        - --leader-election-id=cluster-operator-fyre
+        env:
+        - name: ANSIBLE_GATHERING
+          value: explicit
+        image: quay.io/moyingbj/cluster-operator-fyre:0.0.15
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 6789
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        name: manager
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 6789
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        securityContext:
+          allowPrivilegeEscalation: false
+      securityContext:
+        runAsNonRoot: true
+      serviceAccountName: cluster-operator-fyre-controller-manager
+      terminationGracePeriodSeconds: 10

--- a/gitops-charts/cluster-operator-fyre/templates/qb_large.yaml
+++ b/gitops-charts/cluster-operator-fyre/templates/qb_large.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.sample.quickburn.large }}
+apiVersion: clusters.ibm.com/v1alpha1
+kind: OpenShiftFyre
+metadata:
+  name: openshiftfyre-qb-large
+  namespace: {{ default "default" .Release.Namespace }}
+spec:
+  # Add fields here
+  providerSecretRef: {{ default "default" .Release.Namespace }}-fyre-secret
+  ocpVersion: "4.8.27"
+  size: "large"
+  argocd:
+    namespace: {{ .Values.argo.namespace }}
+{{- end }}

--- a/gitops-charts/cluster-operator-fyre/templates/qb_medium.yaml
+++ b/gitops-charts/cluster-operator-fyre/templates/qb_medium.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.sample.quickburn.medium }}
+apiVersion: clusters.ibm.com/v1alpha1
+kind: OpenShiftFyre
+metadata:
+  name: openshiftfyre-qb-medium
+  namespace: {{ default "default" .Release.Namespace }}
+spec:
+  # Add fields here
+  providerSecretRef: {{ default "default" .Release.Namespace }}-fyre-secret
+  ocpVersion: "4.8.27"
+  size: "medium"
+  argocd:
+    namespace: {{ .Values.argo.namespace }}
+{{- end }}

--- a/gitops-charts/cluster-operator-fyre/templates/secret.yaml
+++ b/gitops-charts/cluster-operator-fyre/templates/secret.yaml
@@ -1,0 +1,12 @@
+---
+{{- $product_group_id := toString .Values.fyre.credential.product_group_id -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ default "default" .Release.Namespace }}-fyre-secret
+  namespace: {{ default "default" .Release.Namespace }}
+data:
+  password: "{{ b64enc .Values.fyre.credential.password }}"
+  product_group_id: "{{ b64enc $product_group_id }}"
+  username: "{{ b64enc .Values.fyre.credential.username }}"
+type: Opaque

--- a/gitops-charts/cluster-operator-fyre/values.yaml
+++ b/gitops-charts/cluster-operator-fyre/values.yaml
@@ -1,0 +1,14 @@
+---
+fyre:
+  credential:
+    username: REPLACE_IT
+    password: REPLACE_IT
+    product_group_id: REPLACE_IT
+
+argo:
+  namespace: openshift-gitops
+
+sample:
+  quickburn:
+    large: false
+    medium: false


### PR DESCRIPTION
This is the chart for Cluster Operator for Fyre, which is an Ansible Operator aimed to manage OpenShift clusters on IBM Fyre automatically driven by Kubernetes Custom Resources. It can be used to launch QuickBurn clusters.