### PR TITLE
Add custom humio chart

### DIFF
--- a/gitops-charts/humio-helm-charts/charts/humio-core/templates/check-prereqs-job.yaml
+++ b/gitops-charts/humio-helm-charts/charts/humio-core/templates/check-prereqs-job.yaml
@@ -1,0 +1,64 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: check-prereqs
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1000"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Release.Name }}-check-prereqs
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1000"
+rules:
+- apiGroups: ["storage.k8s.io"]
+  resources:
+  - storageclass
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Release.Name }}-check-prereqs
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1000"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Release.Name }}-check-prereqs
+subjects:
+- kind: ServiceAccount
+  name: check-prereqs
+  namespace: {{ default "default" .Release.Namespace }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: check-prereqs
+  annotations:
+    argocd.argoproj.io/sync-wave: "-900"
+spec:
+  template:
+    spec:
+      containers:
+        - name: check-prereqs
+          image: quay.io/openshift/origin-cli:latest
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -x
+
+              while : ; do
+                if oc get sc -o "jsonpath={.items[*].metadata.annotations['storageclass\.kubernetes\.io/is-default-class']}" | grep -q ^true$; then
+                  echo "INFO: Default storage class available."
+                  exit 0
+                fi
+                echo "INFO: Default storage class not available, waiting."
+                sleep 10
+              done
+      restartPolicy: Never
+      serviceAccountName: check-prereqs
+  backoffLimit: 10

--- a/gitops-charts/humio-helm-charts/charts/humio-core/templates/post-install-job-balance.yaml
+++ b/gitops-charts/humio-helm-charts/charts/humio-core/templates/post-install-job-balance.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: "{{.Chart.Name}}-{{.Chart.Version}}"
   annotations:
 spec:
-  ttlSecondsAfterFinished: 600
+  # ttlSecondsAfterFinished: 600
   template:
     metadata:
       name: "{{.Release.Name}}"

--- a/gitops-charts/humio-helm-charts/charts/humio-core/templates/post-install-job-create-single-user-token.yaml
+++ b/gitops-charts/humio-helm-charts/charts/humio-core/templates/post-install-job-create-single-user-token.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: "{{.Chart.Name}}-{{.Chart.Version}}"
   annotations:
 spec:
-  #ttlSecondsAfterFinished: 600
+  # ttlSecondsAfterFinished: 600
   template:
     metadata:
       name: "{{.Release.Name}}"

--- a/gitops-charts/humio-helm-charts/charts/humio-core/templates/post-install-job-create-tokens.yaml
+++ b/gitops-charts/humio-helm-charts/charts/humio-core/templates/post-install-job-create-tokens.yaml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: "{{.Chart.Name}}-{{.Chart.Version}}"
   annotations:
 spec:
-  #ttlSecondsAfterFinished: 600
+  # ttlSecondsAfterFinished: 600
   template:
     metadata:
       name: "{{.Release.Name}}"

--- a/gitops-charts/humio-helm-charts/charts/humio-fluentbit/templates/flent-bit-post-install-update-ingtoken-job.yaml
+++ b/gitops-charts/humio-helm-charts/charts/humio-fluentbit/templates/flent-bit-post-install-update-ingtoken-job.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: "{{.Chart.Name}}-{{.Chart.Version}}"
   annotations:
 spec:
-  ttlSecondsAfterFinished: 600
+  # ttlSecondsAfterFinished: 600
   template:
     metadata:
       name: "{{.Release.Name}}"

--- a/gitops-charts/humio-helm-charts/charts/humio-metrics/templates/post-install-job-create-dashboards.yaml
+++ b/gitops-charts/humio-helm-charts/charts/humio-metrics/templates/post-install-job-create-dashboards.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: "{{.Chart.Name}}-{{.Chart.Version}}"
   annotations:
 spec:
-  ttlSecondsAfterFinished: 600
+  # ttlSecondsAfterFinished: 600
   template:
     metadata:
       name: "{{.Release.Name}}"

--- a/gitops-charts/humio-helm-charts/values.yaml
+++ b/gitops-charts/humio-helm-charts/values.yaml
@@ -23,8 +23,8 @@ humio-core:
      cpu: 2
      memory: 8Gi
     requests:
-     cpu: 1
-     memory: 6Gi
+     cpu: 500m
+     memory: 2Gi
 
   cp-helm-charts:
     cp-kafka:


### PR DESCRIPTION
This PR includes some customization added to Humio chart:
- A prereq check job to check storage class availability before kick off the Humio deployment
- Remove ttlSecondsAfterFinished from some jobs to avoid the OutOfSync issue when working w/ Argo CD
- Decreased the requested cpu and memory to better support all-in-one sandbox w/ restricted cpu and memory resource when working w/ CP4WAIOps deployed in the same cluster