### PR TITLE
Update single-user-secret.yaml

### DIFF
--- a/gitops-charts/humio-helm-charts/charts/humio-core/templates/single-user-secret.yaml
+++ b/gitops-charts/humio-helm-charts/charts/humio-core/templates/single-user-secret.yaml
@@ -4,7 +4,7 @@ metadata:
   name: developer-user-password
   annotations:
     "helm.sh/hook": "pre-install"
-    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-delete-policy": hook-succeeded
 type: Opaque
 data:
   password: {{ randAlphaNum 24 | b64enc | quote }}


### PR DESCRIPTION
To fix the intermittent issue of missing developer-user-password secret when deploying humio.