### PR TITLE
Drop the use of routepath function in humio chart

### DIFF
--- a/gitops-charts/humio-helm-charts/charts/humio-core/templates/http-service.yaml
+++ b/gitops-charts/humio-helm-charts/charts/humio-core/templates/http-service.yaml
@@ -14,7 +14,7 @@ metadata:
     name: "Humio"
     id: "administer-mcm"
     roles: "ClusterAdministrator,Administrator,Operator,Viewer"
-    url: http://{{ include "routepath" (list . ) }}
+    # url: http://{{ include "routepath" (list . ) }}
 {{ end }}
 spec:
   type: {{ .Values.service.type }}

--- a/gitops-charts/humio-helm-charts/charts/humio-core/templates/humio-resource-locker.yaml
+++ b/gitops-charts/humio-helm-charts/charts/humio-core/templates/humio-resource-locker.yaml
@@ -1,0 +1,27 @@
+{{ if .Values.openshift.host }}
+apiVersion: redhatcop.redhat.io/v1alpha1
+kind: ResourceLocker
+metadata:
+  name: humio-resource-locker
+  namespace: resource-locker-operator
+spec:
+  patches:
+  - id: patch-service-annotation
+    patchTemplate: |
+      metadata:
+        annotations:
+          url: {{ (index . 0).spec.host }}
+    patchType: application/merge-patch+json
+    sourceObjectRefs:
+    - apiVersion: route.openshift.io/v1
+      kind: Route
+      name: "{{ include "humio-core.fullname" $ }}"
+      namespace: "{{ .Release.Namespace }}"
+    targetObjectRef:
+      apiVersion: v1
+      kind: Service
+      name: {{ include "humio-core.fullname" . }}-http
+      namespace: "{{ .Release.Namespace }}"
+  serviceAccountRef:
+    name: resource-locker-operator-controller-manager
+{{ end }}

--- a/gitops-charts/humio-helm-charts/charts/humio-core/templates/route.yaml
+++ b/gitops-charts/humio-helm-charts/charts/humio-core/templates/route.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  host: {{ include "routepath" (list . ) }}
+  # host: {{ include "routepath" (list . ) }}
   port:
     targetPort: http
   to:


### PR DESCRIPTION
Use resource locker instead to patch service annotation from route, so that avoid user specifying the host of humio route.